### PR TITLE
Ignore unexposed objc declarations

### DIFF
--- a/apple/diffreport/Sources/diffreportlib/diffreport.swift
+++ b/apple/diffreport/Sources/diffreportlib/diffreport.swift
@@ -370,6 +370,8 @@ func extractAPINodeMap(from sourceKittenNode: SourceKittenNode, parentUsr: Strin
         continue
       } else if let comment = sourceKittenNode["key.doc.comment"] as? String, comment.contains(":nodoc:") {
         continue
+      } else if let kind = sourceKittenNode["key.kind"] as? String, kind == "source.lang.objc.decl.unexposed" {
+        continue
       }
       var node = apiNode(from: sourceKittenNode)
 


### PR DESCRIPTION
Unexposed declarations are not part of the API, so ignore them.

The issue of unexposed items being reported  was seem when comparing
different versions of an objc library. In the old version, header files
contained a static assert which was removed in a newer version.

Since SourceKitten crashes when pasring the static assert, a
preprocessor define was used to remove the static_assert in the old
version. The end result is that the old API contained an empty statement
terminated by a semicolon. The new API did not contain that statement.
The reported differences between the APIs contained the following:

    *removed* sourcekitten.source.lang.objc.decl.unexposed: ` + undoc`