### PR TITLE
Really ignore unexposed objc declarations

### DIFF
--- a/apple/diffreport/Sources/diffreportlib/diffreport.swift
+++ b/apple/diffreport/Sources/diffreportlib/diffreport.swift
@@ -370,7 +370,7 @@ func extractAPINodeMap(from sourceKittenNode: SourceKittenNode, parentUsr: Strin
         continue
       } else if let comment = sourceKittenNode["key.doc.comment"] as? String, comment.contains(":nodoc:") {
         continue
-      } else if let kind = sourceKittenNode["key.kind"] as? String, kind == "source.lang.objc.decl.unexposed" {
+      } else if let kind = sourceKittenNode["key.kind"] as? String, kind == "sourcekitten.source.lang.objc.decl.unexposed" {
         continue
       }
       var node = apiNode(from: sourceKittenNode)

--- a/apple/diffreport/Tests/diffreportlibTests/UnitTests.swift
+++ b/apple/diffreport/Tests/diffreportlibTests/UnitTests.swift
@@ -26,6 +26,7 @@ class UnitTests: XCTestCase {
     ("testAddition", testAddition),
     ("testDeletion", testDeletion),
     ("testModification", testModification),
+    ("testIgnoreUnexposed", testIgnoreUnexposed),
   ]
   
   func testNoChanges() throws {
@@ -99,6 +100,11 @@ class UnitTests: XCTestCase {
     XCTAssertEqual(report["MDCAlertControllerView"]!.first!,
                    .addition(apiType: "property",
                              name: "`buttonInkColor` in `MDCAlertControllerView`"))
+  }
+
+  func testIgnoreUnexposed() throws {
+      let report = try generateReport(forOld: ";", new: "")
+      XCTAssert(report.isEmpty)
   }
 
   let oldPath = ProcessInfo.processInfo.environment["TMPDIR"]!.appending("old/Header.h")


### PR DESCRIPTION
Commit 9b9626371064 (Ignore unexposed objc declarations) attempted to
fix the problem of reporting API changes for unexposed symbols, but due
to a typo it didn't actually fix the problem.